### PR TITLE
Updated the globals to be compatible with Foundry 14

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,10 +1,10 @@
 {
   "title": "Alien RPG - Motion Tracker",
   "description": "Allowing players to actually have a motion tracker visually in the game. The motion tracker is a tool that tracks moving objects. Here, we will show position of closest active and visible tokens filtered by some metrics as distance or even statuses.",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "compatibility": {
     "minimum": "11",
-    "verified": "13"
+    "verified": "14"
   },
   "esmodules": [
     "scripts/motion_tracker.js"

--- a/module.json
+++ b/module.json
@@ -40,8 +40,8 @@
       "url": "https://github.com/pplans/"
     }
   ],
-  "manifest": "https://raw.githubusercontent.com/pplans/foundry-vtt-module-motion-tracker/main/module.json",
-  "download": "https://github.com/pplans/foundry-vtt-module-motion-tracker/archive/refs/heads/main.zip",
+  "manifest": "https://raw.githubusercontent.com/bneumann/foundry-vtt-module-motion-tracker/refs/heads/fix/updateTo14/module.json",
+  "download": "https://github.com/bneumann/foundry-vtt-module-motion-tracker/archive/refs/heads/fix/updateTo14.zip",
   "license": "readme.md",
   "id": "motion_tracker",
   "relationships": {

--- a/module.json
+++ b/module.json
@@ -40,8 +40,8 @@
       "url": "https://github.com/pplans/"
     }
   ],
-  "manifest": "https://raw.githubusercontent.com/bneumann/foundry-vtt-module-motion-tracker/refs/heads/fix/updateTo14/module.json",
-  "download": "https://github.com/bneumann/foundry-vtt-module-motion-tracker/archive/refs/heads/fix/updateTo14.zip",
+  "manifest": "https://raw.githubusercontent.com/pplans/foundry-vtt-module-motion-tracker/main/module.json",
+  "download": "https://github.com/pplans/foundry-vtt-module-motion-tracker/archive/refs/heads/main.zip",
   "license": "readme.md",
   "id": "motion_tracker",
   "relationships": {

--- a/scripts/motion_tracker.js
+++ b/scripts/motion_tracker.js
@@ -142,18 +142,18 @@ Hooks.on('controlToken', (_token) =>
     
 	static ALL_DEFAULT_OPTIONS(user = game.user)
 	{
-		return mergeObject(MotionTracker.DEFAULT_OPTIONS, MotionTracker.DEFAULT_APPEARANCE(user));
+		return foundry.utils.mergeObject(MotionTracker.DEFAULT_OPTIONS, MotionTracker.DEFAULT_APPEARANCE(user));
 	}
     
 	static get CONFIG()
 	{
-		return mergeObject(MotionTracker.DEFAULT_OPTIONS, game.settings.get(settings.REGISTER_CODE, 'settings'));
+		return foundry.utils.mergeObject(MotionTracker.DEFAULT_OPTIONS, game.settings.get(settings.REGISTER_CODE, 'settings'));
 	}
     
 	static APPEARANCE(user = game.user)
 	{
 		let userAppearance = user.getFlag(settings.REGISTER_CODE, 'appearance');
-		return mergeObject(MotionTracker.DEFAULT_APPEARANCE(user), userAppearance);
+		return foundry.utils.mergeObject(MotionTracker.DEFAULT_APPEARANCE(user), userAppearance);
 	}
     
 	static ALL_CUSTOMIZATION(user = game.user)
@@ -163,7 +163,7 @@ Hooks.on('controlToken', (_token) =>
     
 	static ALL_CONFIG(user = game.user)
 	{
-		return mergeObject(MotionTracker.CONFIG, MotionTracker.APPEARANCE(user));
+		return foundry.utils.mergeObject(MotionTracker.CONFIG, MotionTracker.APPEARANCE(user));
 	}
     
 	/**
@@ -419,7 +419,7 @@ class MotionTrackerWindow extends Application
 
 	static get defaultOptions()
 	{
-		return mergeObject(super.defaultOptions,
+		return foundry.utils.mergeObject(super.defaultOptions,
 		{
 			title: game.i18n.localize('MOTIONTRACKER.MotionTrackerDialogTitle'),
 			id: "motion-tracker-window",
@@ -434,7 +434,7 @@ class MotionTrackerWindow extends Application
 	 ******************************/
 	getData(options)
 	{
-		let data = mergeObject(MotionTracker.CONFIG, game.settings.get(settings.REGISTER_CODE, 'settings'), { insertKeys: false, insertValues: false });
+		let data = foundry.utils.mergeObject(MotionTracker.CONFIG, game.settings.get(settings.REGISTER_CODE, 'settings'), { insertKeys: false, insertValues: false });
 		data.ui = {
 				isAdmin: game.user.hasRole(CONST.USER_ROLES.ASSISTANT)
 				, fakeSignalsIcon: MotionTracker.CONFIG.general.useFakeSignals?'motion-tracker-options-use-fake-signals-ico':'motion-tracker-options-not-use-fake-signals-ico'

--- a/scripts/motion_tracker.js
+++ b/scripts/motion_tracker.js
@@ -15,7 +15,7 @@ Hooks.on("renderSceneControls", async (app, html, data) => {
 	if(hasAdminRights())
 	{
 		const controlButtonIcon = `${settings.PATH}/textures/motion_tracker_ico.webp`;
-		const mtButtonHtml = await renderTemplate(`${settings.TEMPLATE_PATH}/menu_button.html`, {controlButtonIcon});
+		const mtButtonHtml = await foundry.applications.handlebars.renderTemplate(`${settings.TEMPLATE_PATH}/menu_button.html`, {controlButtonIcon});
 		
 		const controlId = "#scene-controls-layers";
 		const controlItemId = controlId + " button[data-control='motion-tracker']";
@@ -269,7 +269,7 @@ Hooks.on('controlToken', (_token) =>
 		{
 			if(!game.user.getFlag(settings.REGISTER_CODE,'appearance'))
 			{
-				renderTemplate("modules/motion_tracker/templates/welcomeMessage.html", {}).then((html)=>
+				foundry.applications.handlebars.renderTemplate("modules/motion_tracker/templates/welcomeMessage.html", {}).then((html)=>
 				{
 					let options = {
 						whisper:[game.user.id],
@@ -282,7 +282,7 @@ Hooks.on('controlToken', (_token) =>
 		}
 		if(game.user != null && !game.user.getFlag(settings.REGISTER_CODE, settings.VERSION))
 		{
-			renderTemplate("modules/motion_tracker/templates/updateMessage.html", {}).then((html)=>
+			foundry.applications.handlebars.renderTemplate("modules/motion_tracker/templates/updateMessage.html", {}).then((html)=>
 			{
 				let options = {
 					whisper:[game.user.id],
@@ -401,7 +401,7 @@ Hooks.on('controlToken', (_token) =>
 /**
  * Application window for the MotionTracker
  */
-class MotionTrackerWindow extends Application
+class MotionTrackerWindow extends foundry.appv1.api.Application
 {
 	constructor(_motionTracker, options={})
 	{

--- a/scripts/motion_tracker_device.js
+++ b/scripts/motion_tracker_device.js
@@ -567,7 +567,7 @@ export class MotionTrackerDevice
 			if(x>0.1 && x<0.2 && !this.waveLock)
 			{
 				this.waveLock = true
-				AudioHelper.play({ src:conf.audio.wave.src, volume: conf.audio.wave.volume * this.volume, autoplay: true }, false)
+				foundry.audio.AudioHelper.play({ src:conf.audio.wave.src, volume: conf.audio.wave.volume * this.volume, autoplay: true }, false)
 				// Timeout should follow length of audio, with a few extra ms
 				setTimeout(() => this.waveLock = false, 200)
 			}
@@ -582,7 +582,7 @@ export class MotionTrackerDevice
 					sound = conf.audio.far;
 
 				this.soundLock = true
-				AudioHelper.play({ src:sound.src, volume: sound.volume * this.volume, autoplay: true }, false)
+				foundry.audio.AudioHelper.play({ src:sound.src, volume: sound.volume * this.volume, autoplay: true }, false)
 				// Timeout should follow length of audio, with a few extra ms
 				setTimeout(() => this.soundLock = false, 1200)
 			}

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -163,7 +163,7 @@ function gmOnly_Settings(callbackResize)
 class MotionTrackerConfig extends FormApplication
 {
 	static get defaultOptions() {
-		return mergeObject(super.defaultOptions,
+		return foundry.utils.mergeObject(super.defaultOptions,
 		{
 			title: game.i18n.localize("MOTIONTRACKER.configTitle"),
 			id: "motion-tracker-config",
@@ -177,7 +177,7 @@ class MotionTrackerConfig extends FormApplication
 
 	getData(options)
 	{
-		let data = mergeObject(MotionTracker.CONFIG, game.settings.get(REGISTER_CODE, 'settings'), { insertKeys: false, insertValues: false });
+		let data = foundry.utils.mergeObject(MotionTracker.CONFIG, game.settings.get(REGISTER_CODE, 'settings'), { insertKeys: false, insertValues: false });
 		data.general.useFakeSignalsChecked = data.general.useFakeSignals ? 'checked':'';
 		data.general.applyScreenGlitchChecked = data.general.applyScreenGlitch ? 'checked':'';
 		data.general.enableFastTokenChangeChecked = data.general.enableFastTokenChange?'checked':'';
@@ -289,7 +289,7 @@ class MotionTrackerConfig extends FormApplication
 			}
 		};
 
-		let settings = mergeObject(MotionTracker.CONFIG, data, { insertKeys: false, insertValues: false });
+		let settings = foundry.utils.mergeObject(MotionTracker.CONFIG, data, { insertKeys: false, insertValues: false });
 
 		if(game.motion_tracker)
 		{

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -160,7 +160,7 @@ function gmOnly_Settings(callbackResize)
 /**
  * Form application to configure settings of the Motion Tracker.
  */
-class MotionTrackerConfig extends FormApplication
+class MotionTrackerConfig extends foundry.appv1.api.FormApplication
 {
 	static get defaultOptions() {
 		return foundry.utils.mergeObject(super.defaultOptions,
@@ -226,7 +226,7 @@ class MotionTrackerConfig extends FormApplication
 		{
 			event.preventDefault();
 			let target = button.getAttribute('data-target');
-			let fp = FilePicker.fromButton(button);
+			let fp = foundry.applications.apps.FilePicker.fromButton(button);
 			this.filepickers.push({
 				target: target,
 				app: fp
@@ -238,7 +238,7 @@ class MotionTrackerConfig extends FormApplication
 	_onReset(event)
 	{
 		event.preventDefault();
-		Dialog.confirm({
+		foundry.appv1.api.Dialog.confirm({
 			title: game.i18n.localize('MOTIONTRACKER.SettingsConfirmTitle'),
 			content: `<p>${game.i18n.localize('MOTIONTRACKER.SettingsConfirmContent')}</p>`,
 			yes: () => 


### PR DESCRIPTION
A lot of globals have been deprecated in 13 and removed in 14. This fix changes the lines where the globals have been removed and changes the latest version.
My guess is, that it is a breaking change for older versions, but I have not tested them with 11 or 12.